### PR TITLE
unreversed order of words in post_sync key option

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -138,7 +138,9 @@ void MainWindow::load_config(QString filename) {
 				qInfo() << "Invalid sync stream config: " << oss;
 				continue;
 			}
-			QString key = words.takeFirst() + ' ' + words.takeFirst();
+			QString first = words.takeFirst();
+			QString second = words.takeFirst();
+			QString key = first + ' ' + second;1
 
 			int val = 0;
 			for (const auto &word : words) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -132,26 +132,30 @@ void MainWindow::load_config(QString filename) {
 		// ----------------------------
 		QStringList onlineSyncStreams = pt.value("OnlineSync", QStringList()).toStringList();
 		for (QString &oss : onlineSyncStreams) {
-			QStringList words = oss.split(' ', QString::SkipEmptyParts);
-			// The first two words ("StreamName (PC)") are the stream identifier
-			if (words.length() < 2) {
-				qInfo() << "Invalid sync stream config: " << oss;
-				continue;
-			}
-			QString first = words.takeFirst();
-			QString second = words.takeFirst();
-			QString key = first + ' ' + second;1
+			QStringList entries = oss.split(',', QString::SkipEmptyParts);
+			for (const auto &entry : entries) {
+				QStringList words = entry.split(' ', QString::SkipEmptyParts);
+				// The first two words ("StreamName (PC)") are the stream identifier
+				if (words.length() < 2) {
+					qInfo() << "Invalid sync stream config: " << oss;
+					continue;
+				}
 
-			int val = 0;
-			for (const auto &word : words) {
-				if (word == "post_clocksync") { val |= lsl::post_clocksync; }
-				if (word == "post_dejitter") { val |= lsl::post_dejitter; }
-				if (word == "post_monotonize") { val |= lsl::post_monotonize; }
-				if (word == "post_threadsafe") { val |= lsl::post_threadsafe; }
-				if (word == "post_ALL") { val = lsl::post_ALL; }
+				QString first = words.takeFirst();
+				QString second = words.takeFirst();
+				QString key = first + ' ' + second;
+
+				int val = 0;
+				for (const auto &word : words) {
+					if (word == "post_clocksync") { val |= lsl::post_clocksync; }
+					if (word == "post_dejitter") { val |= lsl::post_dejitter; }
+					if (word == "post_monotonize") { val |= lsl::post_monotonize; }
+					if (word == "post_threadsafe") { val |= lsl::post_threadsafe; }
+					if (word == "post_ALL") { val = lsl::post_ALL; }
+				}
+				syncOptionsByStreamName[key.toStdString()] = val;
+				qInfo() << "stream sync options: " << key << ": " << val;
 			}
-			syncOptionsByStreamName[key.toStdString()] = val;
-			qInfo() << "stream sync options: " << key << ": " << val;
 		}
 
 		// ----------------------------


### PR DESCRIPTION
The second call to takeFirst actually evaluates first so that the order of stream name and host name were reversed in the key.