### PR TITLE
Refactor stream tracking

### DIFF
--- a/LabRecorder.cfg
+++ b/LabRecorder.cfg
@@ -44,7 +44,8 @@
 ; a warning is issued if one of the streams is not present when the record button is pressed
 ; The syntax is as in: RequiredStreams = "BioSemi (MyHostname)","PhaseSpace (MyHostname)","Eyelink (AnotherHostname)"
 ; where the format is identical to what the LabRecorder displays in the "Record from streams" list.
-; RequiredStreams="RequiredExample (PC)" 
+; There must not be any spaces within the parentheses.
+; RequiredStreams="RequiredExample (PC-HOSTNAME)" 
 
 ; === Online Sync ===
 ; A list of sync settings. Each setting follows the following format: "SrcStreamName (SrcHostName) post_FLAG"
@@ -62,3 +63,7 @@
 ; RCSPort to set the port number for the socket; default 22345
 RCSEnabled=1
 RCSPort=22345
+
+; === Auto Start Recording ===
+; Set AutoStart to 1 to automatically start recording as soon as the config file has concluded parsing.
+; AutoStart=1

--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ The Ubuntu releases do not typically ship with the libsl dependencies so you wil
 The LabRecorder displays a list of currently present device streams under "Record from Streams". If you have turned on a device after you have already started the recorder, click the "Update" button to update the list (this takes ca. 2 seconds).
 > For testing you can use a "dummy" device from the `lslexamples` found in the [liblsl release assets](https://github.com/sccn/liblsl/releases) (for example SendData<!--, SendStringMarkers, and SendDataSimple-->).
 
-If you cannot see streams that are provided on another computer, read the section Network Troubleshooting on the NetworkConnectivity page. You can select which streams you want to record from and which not by checking the check boxes next to them.
+If you cannot see streams that are provided on another computer, read the section Network Troubleshooting on the NetworkConnectivity page.
+
+You can select which streams you want to record from and which not by checking the check boxes next to them.
 > ![labrecorder-default.png](doc/labrecorder-default.png)
+
+Note that if you have multiple streams with the same name and host, it is impossible to check only 1. If any is checked then they will all be recorded.
 
 The entry in "Saving to..." shows you the file name (or file name template) where your recording will be stored. You can change this by modifying the Study Root folder (e.g., by clicking the browse button) and the `File Name / Template` field. If the respective directory does not yet exist, it will be created automatically (except if you do not have the permissions to create it). The file name string may contain placeholders that will be replaced by the values in the fields below. Checking the BIDS box will automatically change the filename template to be BIDS compliant. If the file that you are trying to record to already exists, the existing file will be renamed (the string `_oldX` will be appended where X is the lowest number that is not yet occupied by another existing file). This way, it is impossible to accidentally overwrite data.
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -418,7 +418,7 @@ void MainWindow::startRecording() {
 		
 		std::vector<std::string> watchfor;
 		for (const QString &missing : missingStreams) {
-			// TODO: Convert missing to query expected by lsl::resolve_stream
+			// Convert missing to query expected by lsl::resolve_stream
 			// name='BioSemi' and hostname=AASDFSDF
 			// QRegularExpression rx("(\S+)\s+\((\S+)\)");
 			QStringList name_host = missing.split(QRegExp("\\s+"));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -18,11 +18,19 @@ class MainWindow;
 class recording;
 class RemoteControlSocket;
 
-class RecorderItem {
-
+class StreamItem {
+	
 public:
-	QListWidgetItem listItem;
-	std::string uid;
+	StreamItem(std::string stream_name, std::string stream_type, std::string source_id,
+		std::string hostname, bool required)
+		: name(stream_name), type(stream_type), id(source_id), host(hostname), checked(required) {}
+	
+	QString listName() { return QString::fromStdString(name + " (" + host + ")"); }
+	std::string name;
+	std::string type;
+	std::string id;
+	std::string host;
+	bool checked;
 };
 
 
@@ -52,7 +60,6 @@ private slots:
 	void rcsportValueChangedInt(int value);
 
 private:
-	QSet<QString> getCheckedStreams() const;
 	QString replaceFilename(QString fullfile) const;
 	// function for loading / saving the config file
 	QString find_config_file(const char *filename);
@@ -66,9 +73,9 @@ private:
 	int startTime;
 	std::unique_ptr<QTimer> timer;
 
-	QStringList requiredStreams;
-	std::map<std::string, int> syncOptionsByStreamName;
+	QList<StreamItem> knownStreams;
 	QSet<QString> missingStreams;
+	std::map<std::string, int> syncOptionsByStreamName;
 
 	// QString recFilename;
 	QString legacyTemplate;

--- a/src/recording.cpp
+++ b/src/recording.cpp
@@ -133,10 +133,12 @@ void recording::record_from_query_results(const std::string &query) {
 			// for each result...
 			for (auto &result : results) {
 				// if it is a new stream...
+				std::string _uid = result.uid();
+				std::string _src_id = result.source_id();
 				if (!known_uids.count(result.uid()))
 					// and doesn't have a previously seen source id...
-					if (!(!result.source_id().empty() &&
-							(!known_source_ids.count(result.source_id())))) {
+					if (!result.source_id().empty() &&
+							(!known_source_ids.count(result.source_id()))) {
 						std::cout << "Found a new stream named " << result.name()
 								  << ", adding it to the recording." << std::endl;
 						// start a new recording thread


### PR DESCRIPTION
Based off another PR so only pay attention to https://github.com/labstreaminglayer/App-LabRecorder/commit/4a018cd50110603910dd5f0cd19bbe61ef8bb7a4

* Added autoStart to config (Fixes #21)
    * But this didn't make sense unless RequiredStreams was working, which it wasn't.
* resolved streams are now kept track of in `knownStreams`
    * QList, not QSet, means we can have name-host duplicates (Fixes #31)
    * But it's a struct that also holds the source id so duplicates are unlikely.
* missing & required streams are kept track of in `missingStreams`
    * Here we only have "name (host)"
    * The idea of "RequiredStream" is now a stream that will be checked at program launch. Any stream that's checked will stay in the list even if unresolved. If the user checks a resolved stream, then that stream goes offline, and the user clicks update, that stream is now a requires/missing stream. Similarly, if the user unchecks a stream that was originally "required", then updates and it's not resolved, the previously-required stream would disappear from the list.
* "name (host)" now converted to xpath query so streams can be resolved after the file has started. Fixes #29
    * FYI (host) cannot have any spaces within the parentheses.
