### PR TITLE
Qt6

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -11,7 +11,7 @@ on:
     types: ['created']
 
 env:
-  LSL_RELEASE_URL: 'https://github.com/sccn/liblsl/releases/download/v1.14.1b7'
+  LSL_RELEASE_URL: 'https://github.com/sccn/liblsl/releases/download/v1.14.1b9'
   LSL_RELEASE: '1.14.1'
 
 defaults:
@@ -27,26 +27,34 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {name: "ubuntu-20.04", os: "ubuntu-20.04"}
-        - {name: "ubuntu-18.04", os: "ubuntu-18.04"}
+        - name: "ubuntu-20.04"
+          os: "ubuntu-20.04"
+          qt_ver: "6.1.0"
+        - name: "ubuntu-18.04"
+          os: "ubuntu-18.04"
+          qt_ver: "5.15"
         - name: "windows-x64"
           os: "windows-latest"
           cmake_extra: "-T v142,host=x86"
           arch: "amd64"
-          qt: "win64_msvc2019_64"
+          qt_arch: "win64_msvc2019_64"
+          qt_ver: "6.1.0"
         - name: "windows-x86"
           os: "windows-latest"
           cmake_extra: "-T v142,host=x86 -A Win32"
           arch: "i386"
-          qt: "win32_msvc2019"
-        - {name: "macOS-latest", os: "macOS-latest"}
+          qt_arch: "win32_msvc2019"
+          qt_ver: "5.15"
+        - name: "macOS-latest"
+          os: "macOS-latest"
+          qt_ver: "6.1.0"
     steps:
     - uses: actions/checkout@v2
 
     - name: Install liblsl (Ubuntu)
       if: startsWith(matrix.config.os, 'ubuntu-')
       run: |
-           sudo apt install -y libpugixml1v5
+           sudo apt install -y libpugixml-dev
            curl -L ${LSL_RELEASE_URL}/liblsl-${LSL_RELEASE}-$(lsb_release -sc)_amd64.deb -o liblsl.deb
            sudo dpkg -i liblsl.deb
 
@@ -66,8 +74,8 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.12.2
       with:
-         version: '6.1.0'
-         arch: ${{ matrix.config.qt }}
+         version: ${{ matrix.config.qt_ver }}
+         arch: ${{ matrix.config.qt_arch }}
 
     - name: Configure CMake
       run: |
@@ -86,7 +94,7 @@ jobs:
 
     - name: package
       run: |
-           export LD_LIBRARY_PATH=$Qt5_Dir/lib:$LD_LIBRARY_PATH
+           export LD_LIBRARY_PATH=$Qt5_Dir/lib:$Qt6_Dir/lib:$LD_LIBRARY_PATH
            cmake --build build --config Release -j --target package
            cmake -E remove_directory package/_CPack_Packages
 

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -29,10 +29,8 @@ jobs:
         config:
         - name: "ubuntu-20.04"
           os: "ubuntu-20.04"
-          qt_ver: "6.1.0"
         - name: "ubuntu-18.04"
           os: "ubuntu-18.04"
-          qt_ver: "5.15.2"
         - name: "windows-x64"
           os: "windows-latest"
           cmake_extra: "-T v142,host=x86"
@@ -46,7 +44,10 @@ jobs:
           qt_arch: "win32_msvc2019"
           qt_ver: "5.15.2"
         - name: "macOS-latest"
-          os: "macOS-latest"
+          os: "macos-latest"
+          qt_ver: "6.1.0"
+        - name: "macOS-11"
+          os: "macos-11"
           qt_ver: "6.1.0"
     steps:
     - uses: actions/checkout@v2
@@ -65,13 +66,15 @@ jobs:
            7z x liblsl.zip -oLSL
 
     - name: Download liblsl (macOS)
-      if: matrix.config.os == 'macOS-latest'
-      run: |
-           curl -L ${LSL_RELEASE_URL}/liblsl-${LSL_RELEASE}-OSX_amd64.tar.bz2 -o liblsl.tar.bz2
-           mkdir LSL
-           tar -xvf liblsl.tar.bz2 -C LSL
+      if: startsWith(matrix.config.os, 'macos-')
+      run: brew install labstreaminglayer/tap/lsl
 
-    - name: Install Qt
+    - name: Install Qt .deb packages
+      if: startsWith(matrix.config.os, 'ubuntu-')
+      run: sudo apt install -y qtbase5-dev
+
+    - name: Install Qt (Win and Mac)
+      if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macos')
       uses: jurplel/install-qt-action@v2.12.2
       with:
          version: ${{ matrix.config.qt_ver }}
@@ -94,7 +97,7 @@ jobs:
 
     - name: package
       run: |
-           export LD_LIBRARY_PATH=$Qt5_Dir/lib:$Qt6_Dir/lib:$LD_LIBRARY_PATH
+           export LD_LIBRARY_PATH=$Qt5_DIR/lib:$Qt6_DIR/lib:$LD_LIBRARY_PATH
            cmake --build build --config Release -j --target package
            cmake -E remove_directory package/_CPack_Packages
 

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -66,6 +66,7 @@ jobs:
       if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macOS')
       uses: jurplel/install-qt-action@v2.12.2
       with:
+         version: '6.1.1'
          arch: ${{ matrix.config.qt }}
 
     - name: Install Qt .deb packages

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Install liblsl (Ubuntu)
       if: startsWith(matrix.config.os, 'ubuntu-')
       run: |
+           sudo apt install -y libpugixml1v5
            curl -L ${LSL_RELEASE_URL}/liblsl-${LSL_RELEASE}-$(lsb_release -sc)_amd64.deb -o liblsl.deb
            sudo dpkg -i liblsl.deb
 
@@ -63,14 +64,14 @@ jobs:
            tar -xvf liblsl.tar.bz2 -C LSL
 
     - name: Install Qt
-      if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macOS')
+      if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macOS') || startsWith(matrix.config.os, 'ubuntu-18.04')
       uses: jurplel/install-qt-action@v2.12.2
       with:
          version: '6.1.0'
          arch: ${{ matrix.config.qt }}
 
     - name: Install Qt .deb packages
-      if: startsWith(matrix.config.os, 'ubuntu-')
+      if: startsWith(matrix.config.os, 'ubuntu-20.04')
       run: sudo apt install -y qtbase5-dev
 
     - name: Configure CMake

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -64,15 +64,10 @@ jobs:
            tar -xvf liblsl.tar.bz2 -C LSL
 
     - name: Install Qt
-      if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macOS') || startsWith(matrix.config.os, 'ubuntu-18.04')
       uses: jurplel/install-qt-action@v2.12.2
       with:
          version: '6.1.0'
          arch: ${{ matrix.config.qt }}
-
-    - name: Install Qt .deb packages
-      if: startsWith(matrix.config.os, 'ubuntu-20.04')
-      run: sudo apt install -y qtbase5-dev
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -43,11 +43,8 @@ jobs:
           arch: "i386"
           qt_arch: "win32_msvc2019"
           qt_ver: "5.15.2"
-        - name: "macOS-latest"
-          os: "macos-latest"
-          qt_ver: "6.1.0"
-        - name: "macOS-11"
-          os: "macos-11"
+        - name: "macOS-10"
+          os: "macos-10.15"
           qt_ver: "6.1.0"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -18,7 +18,7 @@ defaults:
   run:
     shell: bash
 
-
+# Check qt_ver on # https://download.qt.io/online/qtsdkrepository/
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -32,7 +32,7 @@ jobs:
           qt_ver: "6.1.0"
         - name: "ubuntu-18.04"
           os: "ubuntu-18.04"
-          qt_ver: "5.15"
+          qt_ver: "5.15.2"
         - name: "windows-x64"
           os: "windows-latest"
           cmake_extra: "-T v142,host=x86"
@@ -44,7 +44,7 @@ jobs:
           cmake_extra: "-T v142,host=x86 -A Win32"
           arch: "i386"
           qt_arch: "win32_msvc2019"
-          qt_ver: "5.15"
+          qt_ver: "5.15.2"
         - name: "macOS-latest"
           os: "macOS-latest"
           qt_ver: "6.1.0"

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -11,8 +11,8 @@ on:
     types: ['created']
 
 env:
-  LSL_RELEASE_URL: 'https://github.com/sccn/liblsl/releases/download/v1.14.0'
-  LSL_RELEASE: '1.14.0'
+  LSL_RELEASE_URL: 'https://github.com/sccn/liblsl/releases/download/v1.14.1b7'
+  LSL_RELEASE: '1.14.1'
 
 defaults:
   run:
@@ -66,7 +66,7 @@ jobs:
       if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macOS')
       uses: jurplel/install-qt-action@v2.12.2
       with:
-         version: '6.1.1'
+         version: '6.1.0'
          arch: ${{ matrix.config.qt }}
 
     - name: Install Qt .deb packages

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -29,7 +29,6 @@ jobs:
         config:
         - {name: "ubuntu-20.04", os: "ubuntu-20.04"}
         - {name: "ubuntu-18.04", os: "ubuntu-18.04"}
-        - {name: "ubuntu-16.04", os: "ubuntu-16.04"}
         - name: "windows-x64"
           os: "windows-latest"
           cmake_extra: "-T v142,host=x86"
@@ -43,11 +42,6 @@ jobs:
         - {name: "macOS-latest", os: "macOS-latest"}
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2.11.0
-      with:
-         arch: ${{ matrix.config.qt }}
 
     - name: Install liblsl (Ubuntu)
       if: startsWith(matrix.config.os, 'ubuntu-')
@@ -67,6 +61,16 @@ jobs:
            curl -L ${LSL_RELEASE_URL}/liblsl-${LSL_RELEASE}-OSX_amd64.tar.bz2 -o liblsl.tar.bz2
            mkdir LSL
            tar -xvf liblsl.tar.bz2 -C LSL
+
+    - name: Install Qt
+      if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macOS')
+      uses: jurplel/install-qt-action@v2.12.2
+      with:
+         arch: ${{ matrix.config.qt }}
+
+    - name: Install Qt .deb packages
+      if: startsWith(matrix.config.os, 'ubuntu-')
+      run: sudo apt install -y qtbase5-dev
 
     - name: Configure CMake
       run: |
@@ -88,7 +92,7 @@ jobs:
            export LD_LIBRARY_PATH=$Qt5_Dir/lib:$LD_LIBRARY_PATH
            cmake --build build --config Release -j --target package
            cmake -E remove_directory package/_CPack_Packages
-      
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,26 +5,17 @@ project(LabRecorder
 	DESCRIPTION "Record and write LabStreamingLayer streams to an XDF file"
 	HOMEPAGE_URL "https://github.com/labstreaminglayer/App-LabRecorder/"
 	LANGUAGES C CXX
-	VERSION 1.14.0)
-
-option(LABRECORDER_TRY_QT6 "Search for Qt6 first. Doesn't supported packaging yet." ON)
+	VERSION 1.14.1)
 
 # Needed for customized MacOSXBundleInfo.plist.in
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-find_package(LSL REQUIRED
-	HINTS ${LSL_INSTALL_ROOT}
-	"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/"
-	"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/install"
-	"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/out/build/x64-Release"
-	"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/out/install/x64-Release"
-	PATH_SUFFIXES share/LSL
-)
-
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
 
+# Dependencies
 
+## LSL
 if(ANDROID)
 	set(LIBLSL_SOURCE_PATH "../../LSL/liblsl" CACHE STRING "Path to liblsl sources")
 
@@ -32,7 +23,6 @@ if(ANDROID)
 	# as path of the normal build process
 	add_subdirectory(${LIBLSL_SOURCE_PATH} liblsl_bin)
 	add_library(LSL::lsl ALIAS lsl)
-	find_package(Qt6 COMPONENTS Widgets Network)
 else()
 	find_package(LSL REQUIRED
 		HINTS ${LSL_INSTALL_ROOT}
@@ -44,22 +34,23 @@ else()
 	)
 endif()
 
-if(LABRECORDER_TRY_QT6)
-	find_package(Qt6 QUIET COMPONENTS Widgets Network)
-	if(Qt6_FOUND)
-		qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
-		set(LABRECORDER_QT_VER Qt)
-	endif()
-endif()
-
+## Qt
+# - automoc etc not necessary because it is taken care of by LSLCMake.
+find_package(Qt6 COMPONENTS Widgets Network)
 if(NOT Qt6_FOUND)
-	find_package(Qt5 REQUIRED COMPONENTS Widgets Network)
-	set(LABRECORDER_QT_VER Qt5)
+	# Require 5.15 so we can use version-agnostic linking.
+	find_package(Qt5 5.15 COMPONENTS Core Widgets Network REQUIRED)
 	add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
+else()
+	qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
 endif()
 
+## Threads
 find_package(Threads REQUIRED)
 
+# Targets
+
+## xdfwriter - stand alone library
 add_subdirectory(xdfwriter)
 
 target_sources(${PROJECT_NAME} PRIVATE
@@ -82,8 +73,8 @@ add_executable(LabRecorderCLI MACOSX_BUNDLE
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 	xdfwriter
-	${LABRECORDER_QT_VER}::Widgets
-	${LABRECORDER_QT_VER}::Network
+	Qt::Widgets
+	Qt::Network
 	Threads::Threads
 	LSL::lsl
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum MacOS deployment version")
 
 project(LabRecorder
@@ -6,6 +6,8 @@ project(LabRecorder
 	HOMEPAGE_URL "https://github.com/labstreaminglayer/App-LabRecorder/"
 	LANGUAGES C CXX
 	VERSION 1.14.0)
+
+option(LABRECORDER_TRY_QT6 "Search for Qt6 first. Doesn't supported packaging yet." ON)
 
 # Needed for customized MacOSXBundleInfo.plist.in
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" ${CMAKE_MODULE_PATH})
@@ -22,17 +24,45 @@ find_package(LSL REQUIRED
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
-set(CMAKE_AUTORCC ON)
-find_package(Qt5 REQUIRED COMPONENTS Widgets Network)
+
+if(ANDROID)
+	set(LIBLSL_SOURCE_PATH "../../LSL/liblsl" CACHE STRING "Path to liblsl sources")
+
+	# force include liblsl as target to build with the android toolchain
+	# as path of the normal build process
+	add_subdirectory(${LIBLSL_SOURCE_PATH} liblsl_bin)
+	add_library(LSL::lsl ALIAS lsl)
+	find_package(Qt6 COMPONENTS Widgets Network)
+else()
+	find_package(LSL REQUIRED
+		HINTS ${LSL_INSTALL_ROOT}
+		"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/"
+		"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/install"
+		"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/out/build/x64-Release"
+		"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/out/install/x64-Release"
+		PATH_SUFFIXES share/LSL
+	)
+endif()
+
+if(LABRECORDER_TRY_QT6)
+	find_package(Qt6 QUIET COMPONENTS Widgets Network)
+	if(Qt6_FOUND)
+		qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
+		set(LABRECORDER_QT_VER Qt)
+	endif()
+endif()
+
+if(NOT Qt6_FOUND)
+	find_package(Qt5 REQUIRED COMPONENTS Widgets Network)
+	set(LABRECORDER_QT_VER Qt5)
+	add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
+endif()
 
 find_package(Threads REQUIRED)
 
 add_subdirectory(xdfwriter)
 
-add_executable(${PROJECT_NAME} MACOSX_BUNDLE #WIN32
+target_sources(${PROJECT_NAME} PRIVATE
 	src/main.cpp
 	src/mainwindow.cpp
 	src/mainwindow.h
@@ -52,8 +82,8 @@ add_executable(LabRecorderCLI MACOSX_BUNDLE
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 	xdfwriter
-	Qt5::Widgets
-	Qt5::Network
+	${LABRECORDER_QT_VER}::Widgets
+	${LABRECORDER_QT_VER}::Network
 	Threads::Threads
 	LSL::lsl
 )
@@ -76,24 +106,32 @@ installLSLAuxFiles(${PROJECT_NAME}
 )
 
 if (WIN32)
-	get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
-	get_filename_component(QT5_WINDEPLOYQT_EXECUTABLE ${QT5_QMAKE_EXECUTABLE} PATH)
-	set(QT5_WINDEPLOYQT_EXECUTABLE "${QT5_WINDEPLOYQT_EXECUTABLE}/windeployqt.exe")
+	get_target_property(QT_QMAKE_EXECUTABLE Qt::qmake IMPORTED_LOCATION)
+	get_filename_component(QT_WINDEPLOYQT_EXECUTABLE ${QT_QMAKE_EXECUTABLE} PATH)
+	set(QT_WINDEPLOYQT_EXECUTABLE "${QT_WINDEPLOYQT_EXECUTABLE}/windeployqt.exe")
 
 	add_custom_command(
 		TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir
-			${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE_DIR:${PROJECT_NAME}>)
+		COMMAND ${QT_WINDEPLOYQT_EXECUTABLE}
+		--no-translations --no-system-d3d-compiler
+		--qmldir ${CMAKE_CURRENT_SOURCE_DIR}
+		$<TARGET_FILE_DIR:${PROJECT_NAME}>)
 	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different  
-			$<TARGET_FILE:LSL::lsl>
-			$<TARGET_FILE:xdfwriter>
-			$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		$<TARGET_FILE:LSL::lsl>
+		$<TARGET_FILE:xdfwriter>
+		$<TARGET_FILE_DIR:${PROJECT_NAME}>)
 	add_custom_command(
 		TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy
-			${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
-			$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+		${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
+		$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+endif()
+
+if(Qt6_FOUND)
+	set_target_properties(${PROJECT_NAME} PROPERTIES
+		QT_ANDROID_EXTRA_LIBS "${CMAKE_CURRENT_BINARY_DIR}/liblsl_bin/liblsl.so")
+	qt_finalize_executable(${PROJECT_NAME})
 endif()
 
 set(CPACK_DEBIAN_LABRECORDER_PACKAGE_SECTION "science" CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum MacOS deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum MacOS deployment version")
 
 project(LabRecorder
 	DESCRIPTION "Record and write LabStreamingLayer streams to an XDF file"
@@ -35,11 +35,13 @@ else()
 endif()
 
 ## Qt
-# - automoc etc not necessary because it is taken care of by LSLCMake.
-find_package(Qt6 COMPONENTS Widgets Network)
+set(CMAKE_AUTOMOC ON)  # The later version of this in LSLCMake is somehow not enough.
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+find_package(Qt6 COMPONENTS Core Widgets Network DBus)
 if(NOT Qt6_FOUND)
 	# Require 5.15 so we can use version-agnostic linking.
-	find_package(Qt5 5.15 COMPONENTS Core Widgets Network REQUIRED)
+	find_package(Qt5 5.15 COMPONENTS Core Widgets Network DBus REQUIRED)
 	add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
 else()
 	qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
@@ -75,6 +77,7 @@ target_link_libraries(${PROJECT_NAME}
 	xdfwriter
 	Qt::Widgets
 	Qt::Network
+	Qt::DBus
 	Threads::Threads
 	LSL::lsl
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,13 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 find_package(Qt6 COMPONENTS Core Widgets Network DBus)
 if(NOT Qt6_FOUND)
-	# Require 5.15 so we can use version-agnostic linking.
-	find_package(Qt5 5.15 COMPONENTS Core Widgets Network DBus REQUIRED)
+	# If we require 5.15 then we can use version-agnostic linking, but 5.15 not easily available on Ubuntu.
+	find_package(Qt5 COMPONENTS Core Widgets Network DBus REQUIRED)
 	add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
+    set(LSLAPP_QT_VER Qt5)
 else()
 	qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
+    set(LSLAPP_QT_VER Qt)
 endif()
 
 ## Threads
@@ -75,9 +77,9 @@ add_executable(LabRecorderCLI MACOSX_BUNDLE
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 	xdfwriter
-	Qt::Widgets
-	Qt::Network
-	Qt::DBus
+	${LSLAPP_QT_VER}::Widgets
+	${LSLAPP_QT_VER}::Network
+	${LSLAPP_QT_VER}::DBus
 	Threads::Threads
 	LSL::lsl
 )
@@ -130,3 +132,4 @@ endif()
 
 set(CPACK_DEBIAN_LABRECORDER_PACKAGE_SECTION "science" CACHE INTERNAL "")
 LSLGenerateCPackConfig()
+

--- a/README.md
+++ b/README.md
@@ -5,16 +5,41 @@
 
 The LabRecorder is the default recording program that comes with LSL. It allows to record all streams on the lab network (or a subset) into a single file, with time synchronization between streams.
 
-[Download it from the Releases page](https://github.com/labstreaminglayer/App-LabRecorder/releases).
-
 # File Format
 
 The file format used by the LabRecorder is XDF. This is an open general-purpose format that was designed concurrently with LSL and supports all features of LSL streams. The project page is [here](https://github.com/sccn/xdf). There are importers for MATLAB, EEGLAB, BCILAB, Python, and MoBILAB.
 
 # Getting LabRecorder
 
+## Dependencies
+
+For LabRecorder to work on your system, you might need to first install some dependencies.
+
+### MacOS
+
+In the near future it will be necessary to use [homebrew](https://brew.sh/) to manage LSL Apps and their dependencies:
+* Install homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+* Install liblsl: `brew install labstreaminglayer/tap/lsl`
+* Install Qt6: `brew install qt`
+
+### Linux Ubuntu
+
+The Ubuntu releases do not typically ship with their dependencies so you will also have to download and install those:
+* Download and install the latest [liblsl-{version}-bionic_amd64.deb from its release page](https://github.com/sccn/liblsl/releases)
+    * We hope to make this available via a package manager soon.
+    * You can install liblsl directly by double clicking on it, or with with `sudo dpkg -i {filename}.deb`
+* See the bottom of the [lsl build env docs](https://labstreaminglayer.readthedocs.io/dev/build_env.html).
+    * For most cases, this will amount to `sudo apt-get install qtbase5-dev`
+
+## Downloading LabRecorder
+
+### MacOS
+
+* `brew install labrecorder`
+
+### Others
+
 Navigate to the [`releases` page](https://github.com/labstreaminglayer/App-LabRecorder/releases) and download the latest release for your platform.
-The Ubuntu releases do not typically ship with the libsl dependencies so you will also have to download and install [liblsl from its release page](https://github.com/sccn/liblsl/releases).
 
 # Usage
 

--- a/xdfwriter/CMakeLists.txt
+++ b/xdfwriter/CMakeLists.txt
@@ -4,7 +4,7 @@ project(xdfwriter
 	DESCRIPTION "C++ library for writing XDF files"
 	HOMEPAGE_URL "https://github.com/labstreaminglayer/App-LabRecorder/"
 	LANGUAGES C CXX
-	VERSION 1.14.0)
+	VERSION 1.14.1)
 
 option(LABRECORDER_XDFZ "use Boost.Iostreams for XDFZ support" Off)
 option(LABRECORDER_BOOST_TYPE_CONVERSIONS "Use boost for type conversions" Off)
@@ -16,7 +16,7 @@ add_library(${PROJECT_NAME} xdfwriter.cpp)
 
 add_executable(testxdfwriter test_xdf_writer.cpp)
 
-target_link_libraries(testxdfwriter PRIVATE xdfwriter)
+target_link_libraries(testxdfwriter PRIVATE ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 # Test for floating point format and endianness
@@ -42,8 +42,8 @@ endif()
 if(LABRECORDER_BOOST_TYPE_CONVERSIONS)
 	message(STATUS "Searching Boost for type conversions")
 	find_package(Boost REQUIRED)
-	target_link_libraries(xdfwriter PRIVATE Boost::boost)
-	target_compile_definitions(xdfwriter PUBLIC EXOTIC_ARCH_SUPPORT)
+	target_link_libraries(${PROJECT_NAME} PRIVATE Boost::boost)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC EXOTIC_ARCH_SUPPORT)
 endif()
 
 # Enable xdfz support if Boost::iostreams and Boost.zlib (Windows) or plain zlib (Unix) was found
@@ -51,13 +51,13 @@ if(LABRECORDER_XDFZ)
 	find_package(Boost REQUIRED COMPONENTS iostreams)
 	if(WIN32)
 		find_package(Boost REQUIRED COMPONENTS zlib)
-		target_link_libraries(xdfwriter PRIVATE Boost::iostreams Boost::zlib)
+		target_link_libraries(${PROJECT_NAME} PRIVATE Boost::iostreams Boost::zlib)
 	else()
 		find_package(ZLIB REQUIRED)
-		target_link_libraries(xdfwriter PRIVATE Boost::iostreams ${ZLIB_LIBRARIES})
+		target_link_libraries(${PROJECT_NAME} PRIVATE Boost::iostreams ${ZLIB_LIBRARIES})
 	endif()
 	message(STATUS "Found zlib, enabling support for xdfz files")
-	target_compile_definitions(xdfwriter PUBLIC XDFZ_SUPPORT=1)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC XDFZ_SUPPORT=1)
 endif()
 
 


### PR DESCRIPTION
~The default is still Qt5, unless the target is Android.~
Qt6 is required for Android and deploying with Qt6 needs the most recent commit of liblsl.
When Qt6 isn't found, everything still builds against Qt5, so there's not much changed unless you're actively porting to Qt6 or trying to target Android.

As long as Ubuntu 18.04 is still around, we'll need to support building against Qt5, but packaging apps for Android has gotten a lot better with Qt6.

Ubuntu 16.04 will be reaching its EOL next month, so in the interest of not having lots of `#ifdef`s for long deprecated features removed in Qt6 the PR also drops CI builds for Ubuntu 16.04.