### PR TITLE
Enable "update" RCS command to refresh the stream list

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -598,6 +598,7 @@ void MainWindow::enableRcs(bool bEnable) {
 		uint16_t port = ui->rcsport->value();
 		rcs = std::make_unique<RemoteControlSocket>(port);
 		// TODO: Add some method to RemoteControlSocket to report if its server is listening (i.e. was successful).
+		connect(rcs.get(), &RemoteControlSocket::refresh_streams, this, &MainWindow::refreshStreams);
 		connect(rcs.get(), &RemoteControlSocket::start, this, &MainWindow::rcsStartRecording);
 		connect(rcs.get(), &RemoteControlSocket::stop, this, &MainWindow::stopRecording);
 		connect(rcs.get(), &RemoteControlSocket::filename, this, &MainWindow::rcsUpdateFilename);

--- a/src/tcpinterface.cpp
+++ b/src/tcpinterface.cpp
@@ -24,6 +24,8 @@ void RemoteControlSocket::handleLine(QString s, QTcpSocket *sock) {
 		emit start();
 	else if (s == "stop")
 		emit stop();
+	else if (s == "update")
+			emit refresh_streams();
 	else if (s.contains("filename")) {
 		emit filename(s);
 	} else if (s.contains("select")) {

--- a/src/tcpinterface.h
+++ b/src/tcpinterface.h
@@ -15,6 +15,7 @@ public:
 	RemoteControlSocket(uint16_t port);
 
 signals:
+	void refresh_streams();
 	void start();
 	void stop();
 	void filename(QString s);


### PR DESCRIPTION
The "Update" button was the only button not yet "clickable" from the RCS (issue #57). This PR adds @lokinou's suggested changes).