### PR TITLE
Accept more option values in RCS template handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -634,9 +634,8 @@ void MainWindow::rcsUpdateFilename(QString s) {
 	//	task; run; participant; session; acquisition: base options
 	//	(BIDS) modality: from either the defaults eeg, ieeg, meg, beh or adding a new
 	//		potentially unsupported value.
-	QRegularExpression re("{(?P<option>[a-zA-Z]+)\\:(?P<value>[^\\{\\}\\n\\r\\?\\*\\|\\<\\>\"]+)}");
-	
-	re.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
+	QRegularExpression re("{(?P<option>\\w+?):(?P<value>[^}]*)}");
+
 	QRegularExpressionMatchIterator i = re.globalMatch(s);
 	while (i.hasNext()) {
 		QRegularExpressionMatch match = i.next();


### PR DESCRIPTION
I was unsuccessfully trying to set the recording directory to our main data folder in `/home/user/recordings/project: specialchars{\r|` (which, by the way, is a legal folder name) and clearing the acquisition field by sending `filename {root:/home/user/recordings/project: specialchars{\r|}{acquisition:}` to the the RCS.

This PR greatly simplifies the regex for the option/value parsing, allows empty values and some more characters that might be needed some time.