### PR TITLE
[rcs] Hid some more warnings on start/stop

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -454,23 +454,28 @@ void MainWindow::startRecording() {
 		ui->startButton->setEnabled(false);
 		startTime = (int)lsl::local_clock();
 
-	} else
+	} else if (!hideWarnings) {
 		QMessageBox::information(
 			this, "Already recording", "The recording is already running", QMessageBox::Ok);
+	} else {
+		hideWarnings = false;
+	}
 }
 
 void MainWindow::stopRecording() {
 
-	if (!currentRecording)
-		QMessageBox::information(
-			this, "Not recording", "There is not ongoing recording", QMessageBox::Ok);
-	else {
+	if (currentRecording) {
 		try {
 			currentRecording = nullptr;
 		} catch (std::exception &e) { qWarning() << "exception on stop: " << e.what(); }
 		ui->startButton->setEnabled(true);
 		ui->stopButton->setEnabled(false);
 		statusBar()->showMessage("Stopped");
+	} else if (!hideWarnings) {
+		QMessageBox::information(
+			this, "Not recording", "There is not ongoing recording", QMessageBox::Ok);
+	} else {
+		hideWarnings = false;
 	}
 }
 
@@ -617,7 +622,7 @@ void MainWindow::enableRcs(bool bEnable) {
 		// TODO: Add some method to RemoteControlSocket to report if its server is listening (i.e. was successful).
 		connect(rcs.get(), &RemoteControlSocket::refresh_streams, this, &MainWindow::refreshStreams);
 		connect(rcs.get(), &RemoteControlSocket::start, this, &MainWindow::rcsStartRecording);
-		connect(rcs.get(), &RemoteControlSocket::stop, this, &MainWindow::stopRecording);
+		connect(rcs.get(), &RemoteControlSocket::stop, this, &MainWindow::rcsStopRecording);
 		connect(rcs.get(), &RemoteControlSocket::filename, this, &MainWindow::rcsUpdateFilename);
 		connect(rcs.get(), &RemoteControlSocket::select_all, this, &MainWindow::selectAllStreams);
 		connect(rcs.get(), &RemoteControlSocket::select_none, this, &MainWindow::selectNoStreams);
@@ -640,6 +645,11 @@ void MainWindow::rcsStartRecording() {
 	hideWarnings = true;
 	selectAllStreams();
 	startRecording();
+}
+
+void MainWindow::rcsStopRecording() {
+	hideWarnings = true;
+	stopRecording();
 }
 
 void MainWindow::rcsUpdateFilename(QString s) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -457,8 +457,6 @@ void MainWindow::startRecording() {
 	} else if (!hideWarnings) {
 		QMessageBox::information(
 			this, "Already recording", "The recording is already running", QMessageBox::Ok);
-	} else {
-		hideWarnings = false;
 	}
 }
 
@@ -474,8 +472,6 @@ void MainWindow::stopRecording() {
 	} else if (!hideWarnings) {
 		QMessageBox::information(
 			this, "Not recording", "There is not ongoing recording", QMessageBox::Ok);
-	} else {
-		hideWarnings = false;
 	}
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -57,6 +57,7 @@ private slots:
 	void rcsCheckBoxChanged(bool checked);
 	void rcsUpdateFilename(QString s);
 	void rcsStartRecording();
+	void rcsStopRecording();
 	void rcsportValueChangedInt(int value);
 
 private:


### PR DESCRIPTION
@tstenner @cboulay 

(Hi, I'm tagging you because my last (smallest ever) PR went unnoticed, so I'm not sure if anyone's checking them.)

We use automated remote control a lot at our lab, and sometimes the experiment process sends multiple start or stops in a bunch, which each time adds a popup on LabRecorder (`The recording is already running` and `There is not ongoing recording`). After a while, we can have dozens of those, which make subsequent manual use difficult.

I realize that the nice way to deal with it is to *not* send multiple start/stop, which I also fixed on my end; but given that LabRecorder already has a `hideWarnings` flag for remote control, I figured it might also be used for those two warnings.

While at it, I also added a reset of the flag after each command, otherwise it was never reverted to `false`. Also, while in remote control, it might be useful to log the warning instead of a popup, but I didn't implement that.