### PR TITLE
Install cli only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
 
+option(CLI_ONLY "Only compile the CLI (no GUI)" OFF)
+
 # Dependencies
 
 ## LSL
@@ -34,20 +36,25 @@ else()
 	)
 endif()
 
-## Qt
-set(CMAKE_AUTOMOC ON)  # The later version of this in LSLCMake is somehow not enough.
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
-find_package(Qt6 COMPONENTS Core Widgets Network DBus)
-if(NOT Qt6_FOUND)
-	# If we require 5.15 then we can use version-agnostic linking, but 5.15 not easily available on Ubuntu.
-	find_package(Qt5 COMPONENTS Core Widgets Network DBus REQUIRED)
-	add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
-    set(LSLAPP_QT_VER Qt5)
+if (NOT CLI_ONLY)
+	## Qt
+	set(CMAKE_AUTOMOC ON)  # The later version of this in LSLCMake is somehow not enough.
+	set(CMAKE_AUTORCC ON)
+	set(CMAKE_AUTOUIC ON)
+	find_package(Qt6 COMPONENTS Core Widgets Network DBus)
+	if(NOT Qt6_FOUND)
+		# If we require 5.15 then we can use version-agnostic linking, but 5.15 not easily available on Ubuntu.
+		find_package(Qt5 COMPONENTS Core Widgets Network DBus REQUIRED)
+		add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
+		set(LSLAPP_QT_VER Qt5)
+	else()
+		qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
+		set(LSLAPP_QT_VER Qt)
+	endif()
 else()
-	qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
-    set(LSLAPP_QT_VER Qt)
-endif()
+	#Create a dummy target for LabRecorder
+	#add_custom_target(${PROJECT_NAME} ALL COMMAND touch ${PROJECT_NAME})
+endif(NOT CLI_ONLY)
 
 ## Threads
 find_package(Threads REQUIRED)
@@ -57,31 +64,34 @@ find_package(Threads REQUIRED)
 ## xdfwriter - stand alone library
 add_subdirectory(xdfwriter)
 
-target_sources(${PROJECT_NAME} PRIVATE
-	src/main.cpp
-	src/mainwindow.cpp
-	src/mainwindow.h
-	src/mainwindow.ui
-	src/recording.h
-	src/recording.cpp
-	src/tcpinterface.h
-	src/tcpinterface.cpp
-)
+if (NOT CLI_ONLY)
+	target_sources(${PROJECT_NAME} PRIVATE
+		src/main.cpp
+		src/mainwindow.cpp
+		src/mainwindow.h
+		src/mainwindow.ui
+		src/recording.h
+		src/recording.cpp
+		src/tcpinterface.h
+		src/tcpinterface.cpp
+	)
+
+	target_link_libraries(${PROJECT_NAME}
+		PRIVATE
+		xdfwriter
+		${LSLAPP_QT_VER}::Widgets
+		${LSLAPP_QT_VER}::Network
+		${LSLAPP_QT_VER}::DBus
+		Threads::Threads
+		LSL::lsl
+	)
+endif(NOT CLI_ONLY)
+
 
 add_executable(LabRecorderCLI MACOSX_BUNDLE
 	src/clirecorder.cpp
 	src/recording.h
 	src/recording.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-	PRIVATE
-	xdfwriter
-	${LSLAPP_QT_VER}::Widgets
-	${LSLAPP_QT_VER}::Network
-	${LSLAPP_QT_VER}::DBus
-	Threads::Threads
-	LSL::lsl
 )
 
 target_link_libraries(LabRecorderCLI
@@ -93,43 +103,69 @@ target_link_libraries(LabRecorderCLI
 
 installLSLApp(xdfwriter)
 installLSLApp(testxdfwriter)
-installLSLApp(${PROJECT_NAME})
 installLSLApp(LabRecorderCLI)
-installLSLAuxFiles(${PROJECT_NAME}
-	${PROJECT_NAME}.cfg
-	LICENSE
-	README.md
-)
+if (NOT CLI_ONLY)
+	installLSLApp(${PROJECT_NAME})
+	installLSLAuxFiles(${PROJECT_NAME}
+		${PROJECT_NAME}.cfg
+		LICENSE
+		README.md
+	)
+else()
+	installLSLAuxFiles(LabRecorderCLI
+		${PROJECT_NAME}.cfg
+		LICENSE
+		README.md
+	)
+endif(NOT CLI_ONLY)
+
 
 if (WIN32)
-	get_target_property(QT_QMAKE_EXECUTABLE Qt::qmake IMPORTED_LOCATION)
-	get_filename_component(QT_WINDEPLOYQT_EXECUTABLE ${QT_QMAKE_EXECUTABLE} PATH)
-	set(QT_WINDEPLOYQT_EXECUTABLE "${QT_WINDEPLOYQT_EXECUTABLE}/windeployqt.exe")
+	if(NOT CLI_ONLY)
+		get_target_property(QT_QMAKE_EXECUTABLE Qt::qmake IMPORTED_LOCATION)
+		get_filename_component(QT_WINDEPLOYQT_EXECUTABLE ${QT_QMAKE_EXECUTABLE} PATH)
+		set(QT_WINDEPLOYQT_EXECUTABLE "${QT_WINDEPLOYQT_EXECUTABLE}/windeployqt.exe")
 
-	add_custom_command(
-		TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${QT_WINDEPLOYQT_EXECUTABLE}
-		--no-translations --no-system-d3d-compiler
-		--qmldir ${CMAKE_CURRENT_SOURCE_DIR}
-		$<TARGET_FILE_DIR:${PROJECT_NAME}>)
-	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-		$<TARGET_FILE:LSL::lsl>
-		$<TARGET_FILE:xdfwriter>
-		$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+		add_custom_command(
+			TARGET ${PROJECT_NAME} POST_BUILD
+			COMMAND ${QT_WINDEPLOYQT_EXECUTABLE}
+			--no-translations --no-system-d3d-compiler
+			--qmldir ${CMAKE_CURRENT_SOURCE_DIR}
+			$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+
+		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:LSL::lsl>
+			$<TARGET_FILE:xdfwriter>
+			$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+	else()
+		add_custom_command(TARGET LabRecorderCLI POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:LSL::lsl>
+			$<TARGET_FILE:xdfwriter>
+			$<TARGET_FILE_DIR:LabRecorderCLI>)
+	endif(NOT CLI_ONLY)
 endif()
 
+if (NOT CLI_ONLY)
 add_custom_command(
 	TARGET ${PROJECT_NAME} POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy
 	${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
 	$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+else()
+add_custom_command(
+	TARGET LabRecorderCLI POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy
+	${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
+	$<TARGET_FILE_DIR:LabRecorderCLI>)
+endif(NOT CLI_ONLY)
 
-if(Qt6_FOUND)
+if(Qt6_FOUND AND NOT CLI_ONLY)
 	set_target_properties(${PROJECT_NAME} PROPERTIES
 		QT_ANDROID_EXTRA_LIBS "${CMAKE_CURRENT_BINARY_DIR}/liblsl_bin/liblsl.so")
 	qt_finalize_executable(${PROJECT_NAME})
-endif()
+endif(Qt6_FOUND AND NOT CLI_ONLY)
 
 set(CPACK_DEBIAN_LABRECORDER_PACKAGE_SECTION "science" CACHE INTERNAL "")
 LSLGenerateCPackConfig()
@@ -155,4 +191,4 @@ if(APPLE AND NOT DEFINED ENV{GITHUB_ACTIONS})
 				"
 			)
 	endif()
-endif(APPLE)
+endif(APPLE AND NOT DEFINED ENV{GITHUB_ACTIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,6 @@ if (NOT CLI_ONLY)
 		qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
 		set(LSLAPP_QT_VER Qt)
 	endif()
-else()
-	#Create a dummy target for LabRecorder
-	#add_custom_target(${PROJECT_NAME} ALL COMMAND touch ${PROJECT_NAME})
 endif(NOT CLI_ONLY)
 
 ## Threads
@@ -148,17 +145,17 @@ if (WIN32)
 endif()
 
 if (NOT CLI_ONLY)
-add_custom_command(
-	TARGET ${PROJECT_NAME} POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-	${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
-	$<TARGET_FILE_DIR:${PROJECT_NAME}>)
+	add_custom_command(
+		TARGET ${PROJECT_NAME} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy
+		${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
+		$<TARGET_FILE_DIR:${PROJECT_NAME}>)
 else()
-add_custom_command(
-	TARGET LabRecorderCLI POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-	${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
-	$<TARGET_FILE_DIR:LabRecorderCLI>)
+	add_custom_command(
+		TARGET LabRecorderCLI POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy
+		${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
+		$<TARGET_FILE_DIR:LabRecorderCLI>)
 endif(NOT CLI_ONLY)
 
 if(Qt6_FOUND AND NOT CLI_ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
 
-option(CLI_ONLY "Only compile the CLI (no GUI)" OFF)
+option(BUILD_GUI "Build the GUI, set to off for CLI only build" ON)
 
 # Dependencies
 
@@ -36,7 +36,7 @@ else()
 	)
 endif()
 
-if (NOT CLI_ONLY)
+if (BUILD_GUI)
 	## Qt
 	set(CMAKE_AUTOMOC ON)  # The later version of this in LSLCMake is somehow not enough.
 	set(CMAKE_AUTORCC ON)
@@ -51,7 +51,7 @@ if (NOT CLI_ONLY)
 		qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE MANUAL_FINALIZATION)
 		set(LSLAPP_QT_VER Qt)
 	endif()
-endif(NOT CLI_ONLY)
+endif(BUILD_GUI)
 
 ## Threads
 find_package(Threads REQUIRED)
@@ -61,7 +61,7 @@ find_package(Threads REQUIRED)
 ## xdfwriter - stand alone library
 add_subdirectory(xdfwriter)
 
-if (NOT CLI_ONLY)
+if (BUILD_GUI)
 	target_sources(${PROJECT_NAME} PRIVATE
 		src/main.cpp
 		src/mainwindow.cpp
@@ -82,7 +82,7 @@ if (NOT CLI_ONLY)
 		Threads::Threads
 		LSL::lsl
 	)
-endif(NOT CLI_ONLY)
+endif(BUILD_GUI)
 
 
 add_executable(LabRecorderCLI MACOSX_BUNDLE
@@ -101,7 +101,7 @@ target_link_libraries(LabRecorderCLI
 installLSLApp(xdfwriter)
 installLSLApp(testxdfwriter)
 installLSLApp(LabRecorderCLI)
-if (NOT CLI_ONLY)
+if (BUILD_GUI)
 	installLSLApp(${PROJECT_NAME})
 	installLSLAuxFiles(${PROJECT_NAME}
 		${PROJECT_NAME}.cfg
@@ -114,11 +114,11 @@ else()
 		LICENSE
 		README.md
 	)
-endif(NOT CLI_ONLY)
+endif(BUILD_GUI)
 
 
 if (WIN32)
-	if(NOT CLI_ONLY)
+	if(BUILD_GUI)
 		get_target_property(QT_QMAKE_EXECUTABLE Qt::qmake IMPORTED_LOCATION)
 		get_filename_component(QT_WINDEPLOYQT_EXECUTABLE ${QT_QMAKE_EXECUTABLE} PATH)
 		set(QT_WINDEPLOYQT_EXECUTABLE "${QT_WINDEPLOYQT_EXECUTABLE}/windeployqt.exe")
@@ -141,10 +141,10 @@ if (WIN32)
 			$<TARGET_FILE:LSL::lsl>
 			$<TARGET_FILE:xdfwriter>
 			$<TARGET_FILE_DIR:LabRecorderCLI>)
-	endif(NOT CLI_ONLY)
+	endif(BUILD_GUI)
 endif()
 
-if (NOT CLI_ONLY)
+if (BUILD_GUI)
 	add_custom_command(
 		TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy
@@ -156,13 +156,13 @@ else()
 		COMMAND ${CMAKE_COMMAND} -E copy
 		${CMAKE_CURRENT_SOURCE_DIR}//${PROJECT_NAME}.cfg
 		$<TARGET_FILE_DIR:LabRecorderCLI>)
-endif(NOT CLI_ONLY)
+endif(BUILD_GUI)
 
-if(Qt6_FOUND AND NOT CLI_ONLY)
+if(Qt6_FOUND AND BUILD_GUI)
 	set_target_properties(${PROJECT_NAME} PROPERTIES
 		QT_ANDROID_EXTRA_LIBS "${CMAKE_CURRENT_BINARY_DIR}/liblsl_bin/liblsl.so")
 	qt_finalize_executable(${PROJECT_NAME})
-endif(Qt6_FOUND AND NOT CLI_ONLY)
+endif(Qt6_FOUND AND BUILD_GUI)
 
 set(CPACK_DEBIAN_LABRECORDER_PACKAGE_SECTION "science" CACHE INTERNAL "")
 LSLGenerateCPackConfig()


### PR DESCRIPTION
https://github.com/labstreaminglayer/App-LabRecorder/issues/85

Added CMake option `BUILD_GUI` to allow compiling the command line client without the GUI when it is not needed.

To invoke (linux)
```
mkdir build && cd build && cmake ../ -DBUILD_GUI=OFF
```
Tested compilation in 

Debian 11 5.10.0-15-amd64
cmake version 3.23.2

Windows 10 Pro (vm) build 19044.1766
VS Code 17.2.5