### PR TITLE
Only specify gui executable if enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,13 @@ endif(BUILD_GUI)
 find_package(Threads REQUIRED)
 
 # Targets
-add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
 
 ## xdfwriter - stand alone library
 add_subdirectory(xdfwriter)
 
 if (BUILD_GUI)
+	add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
+
 	target_sources(${PROJECT_NAME} PRIVATE
 		src/main.cpp
 		src/mainwindow.cpp


### PR DESCRIPTION
This change prevents this error when gui is disabled:
```
CMake Error at CMakeLists.txt:55 (add_executable):
  No SOURCES given to target: LabRecorder
```
