### PR TITLE
Rcs QoL update. Select streams manually, removed compulsive select all before start

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -489,6 +489,39 @@ void MainWindow::selectAllStreams() {
 	}
 }
 
+
+void MainWindow::selectRegexStreams(const QString& regex_pattern) {
+	// make filter from regex pattern
+	QRegExp regex_filter(regex_pattern);
+
+	// iterate over the UI checkboxes
+	for (int i = 0; i < ui->streamList->count(); i++) {
+		QListWidgetItem* item = ui->streamList->item(i);
+		QString streamName = item->text();
+
+		// Select entries that match
+		if (regex_filter.exactMatch(streamName))
+			item->setCheckState(Qt::Checked);
+	}
+}
+
+void MainWindow::selectStreams(const QString& search_str) {
+	// Convert the search string to lowercase for case-insensitive matching
+	QString lowerSearchStr = search_str.toLower();
+
+	// Iterate over the UI checkboxes
+	for (int i = 0; i < ui->streamList->count(); i++) {
+		QListWidgetItem* item = ui->streamList->item(i);
+		QString streamName = item->text().toLower(); // Convert the stream name to lowercase
+
+		// Select entries that match (case-insensitive)
+		if (streamName.contains(lowerSearchStr)) {
+			item->setCheckState(Qt::Checked);
+		}
+	}
+}
+
+
 void MainWindow::selectNoStreams() {
 	for (int i = 0; i < ui->streamList->count(); i++) {
 		QListWidgetItem *item = ui->streamList->item(i);
@@ -632,6 +665,8 @@ void MainWindow::enableRcs(bool bEnable) {
 		connect(rcs.get(), &RemoteControlSocket::filename, this, &MainWindow::rcsUpdateFilename);
 		connect(rcs.get(), &RemoteControlSocket::select_all, this, &MainWindow::selectAllStreams);
 		connect(rcs.get(), &RemoteControlSocket::select_none, this, &MainWindow::selectNoStreams);
+		connect(rcs.get(), &RemoteControlSocket::select_stream, this, &MainWindow::selectStreams);
+		connect(rcs.get(), &RemoteControlSocket::select_stream_regex, this, &MainWindow::selectRegexStreams);
 	}
 	bool oldState = ui->rcsCheckBox->blockSignals(true);
 	ui->rcsCheckBox->setChecked(bEnable);
@@ -649,7 +684,8 @@ void MainWindow::rcsStartRecording() {
 	// since we want to avoid a pop-up window when streams are missing or unchecked,
 	// we'll check all the streams and start recording
 	hideWarnings = true;
-	selectAllStreams();
+	// Due to the select all function, I assumed it made no sense to force recording all
+	//selectAllStreams();
 	startRecording();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -49,6 +49,8 @@ private slots:
 	void startRecording(void);
 	void stopRecording(void);
 	void selectAllStreams();
+	void selectStreams(const QString& search_str);
+	void selectRegexStreams(const QString& regex_pattern);
 	void selectNoStreams();
 	void buildFilename();
 	void buildBidsTemplate();

--- a/src/tcpinterface.cpp
+++ b/src/tcpinterface.cpp
@@ -22,14 +22,24 @@ void RemoteControlSocket::handleLine(QString s, QTcpSocket *sock) {
 	else if (s == "stop")
 		emit stop();
 	else if (s == "update")
-			emit refresh_streams();
+		emit refresh_streams();
 	else if (s.contains("filename")) {
 		emit filename(s);
-	} else if (s.contains("select")) {
-		if (s.contains("all")) {
-			emit select_all();
-		} else if (s.contains("none")) {
-			emit select_none();
+	}
+	else if (s.contains("select all"))
+		emit select_all();
+	else if (s.contains("select none"))
+		emit select_none();
+	else if (s.contains("select")) {
+		QString search_str = s.mid(7).trimmed(); // Assuming "select" is 7 characters long
+		if (!search_str.isEmpty()) {
+			emit select_stream(search_str);
+		}
+	}
+	else if (s.contains("regexselect")) {
+		QString regexPattern = s.mid(12).trimmed(); // Assuming "regexselect" is 12 characters long
+		if (!regexPattern.isEmpty()) {
+			emit select_stream_regex(regexPattern);
 		}
 	}
 	sock->write("OK");

--- a/src/tcpinterface.h
+++ b/src/tcpinterface.h
@@ -21,6 +21,8 @@ signals:
 	void filename(QString s);
 	void select_all();
 	void select_none();
+	void select_stream(QString s);
+	void select_stream_regex(QString s);
 
 public slots:
 	void addClient();


### PR DESCRIPTION
Removed the compulsive select all before start when using rcs commands.
Remove control of labrecorder can now provide fine selection of streams

Added 

- select <str>
- regexselect <regex_str>

example
"select liveamp"
"regexselect liveamp[0-9]+"