### PR TITLE
Off-by-one sample_count error

### DIFF
--- a/src/recording.cpp
+++ b/src/recording.cpp
@@ -386,6 +386,7 @@ void recording::typed_transfer_loop(streamid_t streamid, double srate, const inl
 		if (!shutdown_) {
 			timestamps.push_back(first_timestamp);
 			file_.write_data_chunk(streamid, timestamps, chunk, (uint32_t)in->get_channel_count());
+			sample_count += timestamps.size();
 		}
 
 		auto next_pull = Clock::now();


### PR DESCRIPTION
The `sample_count` in the footer seems to be reliably off-by-one in my recordings, irrespective of device (pylsl, ANT).

There's a test file [here](https://github.com/jamieforth/example-files/blob/pr/add-empty-streams-file/empty_streams.xdf),  info [here](https://github.com/jamieforth/example-files/blob/pr/add-empty-streams-file/README.md#empty_streamsxdf). Stream 1 contains 10 samples, but the footer reports 9. This was recorded with pylsl v1.17.6 running on the same host as LabRecorder.

Debian 12, x86_64

Thanks