### PR TITLE
added `%datetime`, `%date`, and `%time` expansions to ISO8601 datetimes

### DIFF
--- a/LabRecorder.cfg
+++ b/LabRecorder.cfg
@@ -14,6 +14,12 @@
 ; %b for task label (same as block in Legacy), %a for name of acquisition parameter set, and %r index.
 ; The BIDS syntax is: path/to/StudyRoot/sub-%p/ses-%s/eeg/sub-%p_ses-%s_task-%b[_acq-%a]_run-%r_eeg.xdf
 ;
+
+; Additionally, %datetime will insert an ISO8601 UTC datetime with milliseconds, the day's date
+; only with %date, or the current time only with %time.
+;; for example syntax is: path/to/StudyRoot/LabRecorder_%datetime_eeg.xdf
+;
+
 ; If neither StorageLocation or StudyRoot is provided then the default root is QStandardPaths::DocumentsLocation/CurrentStudy/
 ; If neither StorageLocation or PathTemplate are provided, then the BIDS format is assumed, or the file template exp%n/block_%b.xdf if BIDS is unchecked.
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -564,6 +564,15 @@ QString MainWindow::replaceFilename(QString fullfile) const {
 	QString run = QString("%1").arg(ui->spin_counter->value(), 3, 10, QChar('0'));
 	fullfile.replace(counterPlaceholder(), run);
 
+	// ISO8601 UTC datetime with milliseconds
+	// Get current UTC once
+	QDateTime nowUtc = QDateTime::currentDateTimeUtc();
+	// Datetime replacements (filename-safe)
+	// QString datetime = QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH--mm--ss.zzzZ"); -- with double-hyphen convention as mentioned on wikipedia: https://en.wikipedia.org/wiki/ISO_8601
+	fullfile.replace("%datetime", nowUtc.toString("yyyy-MM-ddTHHmmss.zzzZ"));
+	fullfile.replace("%date", nowUtc.toString("yyyy-MM-dd"));
+	fullfile.replace("%time", nowUtc.toString("HHmmss.zzzZ"));
+
 	return fullfile.trimmed();
 }
 


### PR DESCRIPTION
I needed this feature for my own files, but in non-BIDS mode I added support for `%datetime`, `%date`, and `%time` expansions to ISO8601 datetimes in filenames. I also updated the corresponding documentation section.