### PR TITLE
fix: error on empty Study Root to prevent silent recording failure

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -181,7 +181,7 @@ void MainWindow::load_config(QString filename) {
 		// StorageLocation
 		QString studyRoot;
 		legacyTemplate.clear();
-		
+
 		if (pt.contains("StorageLocation")) {
 			if (pt.contains("StudyRoot"))
 				throw std::runtime_error("StorageLocation cannot be used if StudyRoot is also specified.");
@@ -400,6 +400,12 @@ void MainWindow::startRecording() {
 			QMessageBox::critical(this, "Filename empty", "Can not record without a file name");
 			return;
 		}
+		if (ui->rootEdit->text().trimmed().isEmpty()) {
+			QMessageBox::critical(this, "Study Root empty",
+				"Can not record without a Study Root folder. "
+				"Please set a Study Root before recording.");
+			return;
+		}
 		recFilename.prepend(QDir::cleanPath(ui->rootEdit->text()) + '/');
 
 		QFileInfo recFileInfo(recFilename);
@@ -431,7 +437,7 @@ void MainWindow::startRecording() {
 					". Please check your permissions.");
 			return;
 		}
-		
+
 		std::vector<std::string> watchfor;
 		for (const QString &missing : std::as_const(missingStreams)) {
             std::string query;


### PR DESCRIPTION
You can reproduce the issue through this "setting" and trying to record a file:

<img width="619" height="450" alt="image" src="https://github.com/user-attachments/assets/c2ef63ee-e2b6-4734-820e-6d9ce15a2d53" />


... it will not be saved, see also:

<img width="1350" height="314" alt="image" src="https://github.com/user-attachments/assets/d12cbbdb-75c0-46d9-b65a-c1cef94f68e7" />


--> hence, here a test that study_root is actually filled in.

We lost some data like this, unfortunately, so with this PR I'd like to prevent such accidents in the future 🙂 