### PR TITLE
ENH: add tooltips to available streams

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -181,7 +181,7 @@ void MainWindow::load_config(QString filename) {
 		// StorageLocation
 		QString studyRoot;
 		legacyTemplate.clear();
-		
+
 		if (pt.contains("StorageLocation")) {
 			if (pt.contains("StudyRoot"))
 				throw std::runtime_error("StorageLocation cannot be used if StudyRoot is also specified.");
@@ -351,6 +351,11 @@ std::vector<lsl::stream_info> MainWindow::refreshStreams() {
 		auto *item = new QListWidgetItem(k.listName(), ui->streamList);
 		item->setCheckState(k.checked ? Qt::Checked : Qt::Unchecked);
 		item->setForeground(good_brush);
+	    item->setToolTip(QString("Name: %1\nType: %2\nHostname: %3\nSource ID: %4")
+            .arg(QString::fromStdString(k.name),
+                 QString::fromStdString(k.type),
+                 QString::fromStdString(k.hostname),
+                 QString::fromStdString(k.id)));
 		ui->streamList->addItem(item);
 	}
 
@@ -431,7 +436,7 @@ void MainWindow::startRecording() {
 					". Please check your permissions.");
 			return;
 		}
-		
+
 		std::vector<std::string> watchfor;
 		for (const QString &missing : std::as_const(missingStreams)) {
             std::string query;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -354,8 +354,8 @@ std::vector<lsl::stream_info> MainWindow::refreshStreams() {
 	    item->setToolTip(QString("Name: %1\nType: %2\nHostname: %3\nSource ID: %4")
             .arg(QString::fromStdString(k.name),
                  QString::fromStdString(k.type),
-                 QString::fromStdString(k.hostname),
-                 QString::fromStdString(k.id)));
+                 QString::fromStdString(k.id),
+                 QString::fromStdString(k.host)));
 		ui->streamList->addItem(item);
 	}
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -351,7 +351,7 @@ std::vector<lsl::stream_info> MainWindow::refreshStreams() {
 		auto *item = new QListWidgetItem(k.listName(), ui->streamList);
 		item->setCheckState(k.checked ? Qt::Checked : Qt::Unchecked);
 		item->setForeground(good_brush);
-	    item->setToolTip(QString("Name: %1\nType: %2\nHostname: %3\nSource ID: %4")
+	    item->setToolTip(QString("Name: %1\nType: %2\nSource ID: %3\nHostname: %4")
             .arg(QString::fromStdString(k.name),
                  QString::fromStdString(k.type),
                  QString::fromStdString(k.id),


### PR DESCRIPTION
This is a quality of life change so that experimenters can get more information about the streams that are currently available.

I tested this after building on my fork.

Build passes: https://github.com/sappelhoff/App-LabRecorder/actions/runs/23839513644/job/69491294834

Screenshots of new behavior:


<img width="699" height="459" alt="image" src="https://github.com/user-attachments/assets/c96c7eb6-11a7-40ef-a01e-5fa14dbb9eb1" />

<img width="698" height="456" alt="image" src="https://github.com/user-attachments/assets/b977d3e5-30a7-4bf1-8010-8c72019f86b0" />


Would appreciate a review 🙏 

cc @cboulay 